### PR TITLE
feat: include api version and load media from CDN

### DIFF
--- a/frontend/src/components/atoms/logo.tsx
+++ b/frontend/src/components/atoms/logo.tsx
@@ -1,7 +1,4 @@
 import { useContext } from 'react';
-import { useRecoilValue } from 'recoil';
-
-import { settingsState } from 'state/settings';
 
 import { ChainlitContext } from 'client-types/*';
 
@@ -11,10 +8,7 @@ interface Props {
 }
 
 export const Logo = ({ style }: Props) => {
-  const { theme } = useRecoilValue(settingsState);
   const apiClient = useContext(ChainlitContext);
 
-  return (
-    <img src={apiClient.getLogoEndpoint(theme)} alt="logo" style={style} />
-  );
+  return <img src={apiClient.getLogoEndpoint()} alt="logo" style={style} />;
 };

--- a/frontend/src/components/molecules/messages/components/Avatar.tsx
+++ b/frontend/src/components/molecules/messages/components/Avatar.tsx
@@ -1,13 +1,5 @@
-import { useContext, useMemo } from 'react';
-
 import { Tooltip } from '@mui/material';
 import Avatar from '@mui/material/Avatar';
-
-import {
-  ChainlitContext,
-  useChatSession,
-  useConfig
-} from '@chainlit/react-client';
 
 interface Props {
   author?: string;
@@ -15,21 +7,8 @@ interface Props {
 }
 
 const MessageAvatar = ({ author, hide }: Props) => {
-  const apiClient = useContext(ChainlitContext);
-  const { chatProfile } = useChatSession();
-  const { config } = useConfig();
-
-  const selectedChatProfile = useMemo(() => {
-    return config?.chatProfiles.find((profile) => profile.name === chatProfile);
-  }, [config, chatProfile]);
-
-  const avatarUrl = useMemo(() => {
-    const isAssistant = !author || author === config?.ui.name;
-    if (isAssistant && selectedChatProfile?.icon) {
-      return selectedChatProfile.icon;
-    }
-    return apiClient?.buildEndpoint(`/avatars/${author || 'default'}`);
-  }, [apiClient, selectedChatProfile, config, author]);
+  const avatarUrl =
+    'https://res.cloudinary.com/snyk/image/upload/v1741689722/snyk-learn/chatbot-avatar.png';
 
   return (
     <span className={`message-avatar`}>

--- a/libs/react-client/src/api/index.tsx
+++ b/libs/react-client/src/api/index.tsx
@@ -49,12 +49,23 @@ export class APIBase {
   ) {}
 
   buildEndpoint(path: string) {
+    let fullUrl = `${this.httpEndpoint}${path}`;
     if (this.httpEndpoint.endsWith('/')) {
       // remove trailing slash on httpEndpoint
-      return `${this.httpEndpoint.slice(0, -1)}${path}`;
-    } else {
-      return `${this.httpEndpoint}${path}`;
+      fullUrl = `${this.httpEndpoint.slice(0, -1)}${path}`;
     }
+
+    // Add version parameter for all API endpoints
+    const API_VERSION = '2024-10-15';
+    const url = new URL(fullUrl);
+
+    const params = new URLSearchParams(url.search);
+    // Check if version parameter already exists
+    if (!params.has('version')) {
+      const separator = url.search ? '&' : '?';
+      url.search = url.search + `${separator}version=${API_VERSION}`;
+    }
+    return url.toString();
   }
 
   checkToken(token: string) {
@@ -247,8 +258,8 @@ export class ChainlitAPI extends APIBase {
     return this.buildEndpoint(`/project/file/${id}${queryParams}`);
   }
 
-  getLogoEndpoint(theme: string) {
-    return this.buildEndpoint(`/logo?theme=${theme}`);
+  getLogoEndpoint() {
+    return 'https://res.cloudinary.com/snyk/image/upload/v1741689720/snyk-learn/chatbot-logo.png';
   }
 
   getOAuthEndpoint(provider: string) {

--- a/libs/react-client/src/useChatSession.ts
+++ b/libs/react-client/src/useChatSession.ts
@@ -76,10 +76,10 @@ const useChatSession = () => {
 
   const _connect = useCallback(
     ({
-      userEnv,
+      _userEnv,
       accessToken
     }: {
-      userEnv: Record<string, string>;
+      _userEnv: Record<string, string>;
       accessToken?: string;
     }) => {
       const { protocol, host, pathname } = new URL(client.httpEndpoint);
@@ -96,7 +96,6 @@ const useChatSession = () => {
           'X-Chainlit-Client-Type': client.type,
           'X-Chainlit-Session-Id': sessionId,
           'X-Chainlit-Thread-Id': idToResume || '',
-          'user-env': JSON.stringify(userEnv),
           'X-Chainlit-Chat-Profile': chatProfile
             ? encodeURIComponent(chatProfile)
             : ''


### PR DESCRIPTION
Created a patch over origina chainlit v1.3.2 for below changes:
- Pass api version param to all the calls made to chainlit server.
- Load logo and avatar media directly from CDN.