### PR TITLE
feat: support additionalQueryParamsForAPI setting in copilot

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -25,6 +25,7 @@ const onError = (error: ClientError) => {
 export const apiClient = new ChainlitAPI(
   httpEndpoint,
   'webapp',
+  {}, // Optional - additionalQueryParams property.
   on401,
   onError
 );

--- a/libs/copilot/src/api.ts
+++ b/libs/copilot/src/api.ts
@@ -2,7 +2,10 @@ import { toast } from 'sonner';
 
 import { ChainlitAPI, ClientError } from '@chainlit/react-client';
 
-export function makeApiClient(chainlitServer: string) {
+export function makeApiClient(
+  chainlitServer: string,
+  additionalQueryParams: Record<string, string>
+) {
   const httpEndpoint = chainlitServer;
 
   const on401 = () => {
@@ -13,5 +16,11 @@ export function makeApiClient(chainlitServer: string) {
     toast.error(error.toString());
   };
 
-  return new ChainlitAPI(httpEndpoint, 'copilot', on401, onError);
+  return new ChainlitAPI(
+    httpEndpoint,
+    'copilot',
+    additionalQueryParams,
+    on401,
+    onError
+  );
 }

--- a/libs/copilot/src/appWrapper.tsx
+++ b/libs/copilot/src/appWrapper.tsx
@@ -14,7 +14,11 @@ interface Props {
 }
 
 export default function AppWrapper({ widgetConfig }: Props) {
-  const apiClient = makeApiClient(widgetConfig.chainlitServer);
+  const additionalQueryParams = widgetConfig?.additionalQueryParamsForAPI;
+  const apiClient = makeApiClient(
+    widgetConfig.chainlitServer,
+    additionalQueryParams || {}
+  );
   const [customThemeLoaded, setCustomThemeLoaded] = useState(false);
 
   function completeInitialization() {

--- a/libs/copilot/src/types.ts
+++ b/libs/copilot/src/types.ts
@@ -9,4 +9,5 @@ export interface IWidgetConfig {
     className?: string;
   };
   customCssUrl?: string;
+  additionalQueryParamsForAPI?: Record<string, string>;
 }

--- a/libs/react-client/src/api/index.tsx
+++ b/libs/react-client/src/api/index.tsx
@@ -46,17 +46,28 @@ export class APIBase {
   constructor(
     public httpEndpoint: string,
     public type: 'webapp' | 'copilot' | 'teams' | 'slack' | 'discord',
+    public additionalQueryParams?: Record<string, string>,
     public on401?: () => void,
     public onError?: (error: ClientError) => void
   ) {}
 
   buildEndpoint(path: string) {
+    let fullUrl = `${this.httpEndpoint}${path}`;
     if (this.httpEndpoint.endsWith('/')) {
       // remove trailing slash on httpEndpoint
-      return `${this.httpEndpoint.slice(0, -1)}${path}`;
-    } else {
-      return `${this.httpEndpoint}${path}`;
+      fullUrl = `${this.httpEndpoint.slice(0, -1)}${path}`;
     }
+
+    const url = new URL(fullUrl);
+
+    // Add additionalQueryParams for all API calls
+    if (this.additionalQueryParams) {
+      const params = new URLSearchParams(this.additionalQueryParams);
+      const separator = url.search ? '&' : '?';
+      url.search = url.search + `${separator}${params.toString()}`;
+    }
+
+    return url.toString();
   }
 
   private async getDetailFromErrorResponse(


### PR DESCRIPTION
### What changes made
- Added `additionalQueryParamsForAPI` option in copilot settings, these configured query params passed while calling to chainlit server, it is useful when chainlit server is behind the proxy or api-gateway which requires some mandatory params.

### NOTE:
- Configured `additionalQueryParamsForAPI` will not be passed in Socket.io requests.

### Related links
- [EDU-3726](https://snyksec.atlassian.net/browse/EDU-3726)